### PR TITLE
fix conflict between always hints and named item hints

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -677,10 +677,8 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
             logger = logging.getLogger('')
             logger.info("Got Bingosync URL. Building board-specific goals.")
             world.item_hints = buildBingoHintList(world.bingosync_url)
-            world.hint_dist_user = bingoDefaults['settings']['hint_dist_user']
         else:
             world.item_hints = bingoDefaults['settings']['item_hints']
-            world.hint_dist_user=bingoDefaults['settings']['hint_dist_user']
 
         if world.tokensanity in ("overworld", "all") and "Suns Song" not in world.item_hints:
             world.item_hints.append("Suns Song")
@@ -722,6 +720,12 @@ def buildWorldGossipHints(spoiler, world, checkedLocations=None):
     for hint in alwaysLocations:
         location = world.get_location(hint.name)
         checkedLocations.add(hint.name)
+        if location.item.name in bingoBottlesForHints and world.hint_dist == 'bingo':
+            always_item = 'Bottle'
+        else:
+            always_item = location.item.name
+        if always_item in world.item_hints:
+            world.item_hints.remove(always_item)
 
         if location.name in world.hint_text_overrides:
             location_text = world.hint_text_overrides[location.name]

--- a/data/Bingo/bingosync_bingo_hints.json
+++ b/data/Bingo/bingosync_bingo_hints.json
@@ -1,41 +1,7 @@
 {
   "settings": {
     "bingosyncURL": "",
-    "item_hints": [],
-    "hint_dist_user": {
-      "name":                  "custom",
-      "gui_name":              "Bingo Hint Distribution for Bingosync Board",
-      "description":           "for debugging",
-      "add_locations":         [],
-      "remove_locations":      [
-          { "location": "ZR Frogs Ocarina Game", "types": ["always"] },
-          { "location": "Song from Ocarina of Time", "types": ["always"] },
-          { "location": "DMT Biggoron", "types": ["always"] },
-          { "location": "Kak 30 Gold Skulltula Reward", "types": ["always"] },
-          { "location": "Kak 40 Gold Skulltula Reward", "types": ["always"] },
-          { "location": "Kak 50 Gold Skulltula Reward", "types": ["always"] }
-      ],
-      "add_items":             [],
-      "remove_items":          [],
-      "dungeons_woth_limit":   2,
-      "dungeons_barren_limit": 1,
-      "named_items_required":  "True",
-      "distribution":          {
-          "trial":      {"order":  1, "weight": 0.0, "fixed":   0, "copies": 2},
-          "always":     {"order":  2, "weight": 0.0, "fixed":   0, "copies": 2},
-          "woth":       {"order":  3, "weight": 0.0, "fixed":   0, "copies": 2},
-          "barren":     {"order":  4, "weight": 0.0, "fixed":   0, "copies": 1},
-          "entrance":   {"order":  5, "weight": 0.0, "fixed":   0, "copies": 2},
-          "sometimes":  {"order":  6, "weight": 0.0, "fixed":   0, "copies": 1},
-          "random":     {"order":  7, "weight": 0.0, "fixed":   0, "copies": 2},
-          "item":       {"order":  8, "weight": 0.0, "fixed":   0, "copies": 2},
-          "song":       {"order":  9, "weight": 0.0, "fixed":   0, "copies": 2},
-          "overworld":  {"order": 10, "weight": 0.0, "fixed":   0, "copies": 2},
-          "dungeon":    {"order": 11, "weight": 0.0, "fixed":   0, "copies": 2},
-          "junk":       {"order": 12, "weight": 1.0, "fixed":   0, "copies": 1},
-          "named-item": {"order": 13, "weight": 0.0, "fixed":   0, "copies": 2}
-      }
-    }
+    "item_hints": []
   },
   "item_pool": {
       "Bottle": 3

--- a/data/Bingo/generic_bingo_hints.json
+++ b/data/Bingo/generic_bingo_hints.json
@@ -14,41 +14,7 @@
       "Iron Boots",
       "Hover Boots",
       "Zeldas Lullaby"
-    ],
-    "hint_dist_user": {
-      "name":                  "custom",
-      "gui_name":              "Plando Test Hint Distribution",
-      "description":           "for debugging",
-      "add_locations":         [],
-      "remove_locations":      [
-          { "location": "ZR Frogs Ocarina Game", "types": ["always"] },
-          { "location": "Song from Ocarina of Time", "types": ["always"] },
-          { "location": "DMT Biggoron", "types": ["always"] },
-          { "location": "Kak 30 Gold Skulltula Reward", "types": ["always"] },
-          { "location": "Kak 40 Gold Skulltula Reward", "types": ["always"] },
-          { "location": "Kak 50 Gold Skulltula Reward", "types": ["always"] }
-      ],
-      "add_items":             [],
-      "remove_items":          [],
-      "dungeons_woth_limit":   2,
-      "dungeons_barren_limit": 1,
-      "named_items_required":  "True",
-      "distribution":          {
-          "trial":      {"order":  1, "weight": 0.0, "fixed":   0, "copies": 2},
-          "always":     {"order":  2, "weight": 0.0, "fixed":   0, "copies": 2},
-          "woth":       {"order":  3, "weight": 0.0, "fixed":   0, "copies": 2},
-          "barren":     {"order":  4, "weight": 0.0, "fixed":   0, "copies": 1},
-          "entrance":   {"order":  5, "weight": 0.0, "fixed":   0, "copies": 2},
-          "sometimes":  {"order":  6, "weight": 0.0, "fixed":   0, "copies": 1},
-          "random":     {"order":  7, "weight": 0.0, "fixed":   0, "copies": 2},
-          "item":       {"order":  8, "weight": 0.0, "fixed":   0, "copies": 2},
-          "song":       {"order":  9, "weight": 0.0, "fixed":   0, "copies": 2},
-          "overworld":  {"order": 10, "weight": 0.0, "fixed":   0, "copies": 2},
-          "dungeon":    {"order": 11, "weight": 0.0, "fixed":   0, "copies": 2},
-          "junk":       {"order": 12, "weight": 1.0, "fixed":   0, "copies": 1},
-          "named-item": {"order": 13, "weight": 0.0, "fixed":   0, "copies": 2}
-      }
-    }
+    ]
   },
   "item_pool": {
       "Bottle": 3


### PR DESCRIPTION
Remove a named item from the hint list if it is already hinted by an always or conditional always hint. Only one instance is removed for each always hint. Multiple instances of named items generate the specified number of hints as a combination of always and named-item types if necessary.

This also consolidates default bingo hint distribution settings into the data/Hints/bingo.json file to be consistent with other hint distributions. The default generic named item list if no bingosync URL is provided still exists and works as expected.